### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Ultralytics Source-Trace 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Overview:
 # This pyproject.toml file manages the build, packaging, and distribution of the Ultralytics Source-Trace library.


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Minor formatting updates to license headers in configuration files for consistency and clarity.

### 📊 Key Changes  
- Adjusted license header format in `.github/workflows/format.yml` and `pyproject.toml` for uniformity:  
  - Unified phrasing as "Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license".

### 🎯 Purpose & Impact  
- 📝 **Improved Consistency**: Ensures license headers across files follow the same structure for better readability.  
- 🔍 **Enhanced Clarity**: Makes license details more consistent and easier to locate, benefitting contributors and users alike.  
- 📜 **No Functional Changes**: These updates do not alter functionality or performance of the project.